### PR TITLE
New function `native.get_module_base`: retrieves the base address of a specified `.so` in the process using `xdl`.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "xdl"]
+	path = app/src/main/cpp/xdl
+	url = https://github.com/hexhacking/xDL.git

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -22,6 +22,11 @@ android {
         versionName = "3.9.4-beta"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+        externalNativeBuild {
+            cmake {
+                cppFlags += ""
+            }
+        }
     }
 
     buildTypes {
@@ -49,6 +54,13 @@ android {
 
     aaptOptions {
         additionalParameters += listOf("--package-id", "0x69", "--allow-reserved-package-id")
+    }
+
+    externalNativeBuild {
+        cmake {
+            path = file("src/main/cpp/CMakeLists.txt")
+            version = "3.22.1"
+        }
     }
 }
 

--- a/app/src/main/cpp/CMakeLists.txt
+++ b/app/src/main/cpp/CMakeLists.txt
@@ -1,0 +1,11 @@
+cmake_minimum_required(VERSION 3.22.1)
+
+project("luahook")
+
+file(GLOB XDL_SRC "xdl/xdl/src/main/cpp/*.c")
+add_library(xdl SHARED ${XDL_SRC})
+target_compile_features(xdl PRIVATE c_std_17)
+target_include_directories(xdl PUBLIC xdl/xdl/src/main/cpp/include)
+
+add_library(luahook SHARED luahook.cpp)
+target_link_libraries(luahook PRIVATE android log PRIVATE xdl)

--- a/app/src/main/cpp/luahook.cpp
+++ b/app/src/main/cpp/luahook.cpp
@@ -1,8 +1,8 @@
+#include <cstring>
 #include <jni.h>
 #include "xdl.h"
 
-extern "C"
-JNIEXPORT jlong JNICALL
+extern "C" JNIEXPORT jlong JNICALL
 Java_com_kulipai_luahook_library_NativeLib_get_1module_1base(JNIEnv *env, jobject thiz, jstring name) {
     const char *chars = env->GetStringUTFChars(name, nullptr);
     int64_t result = 0;
@@ -14,4 +14,30 @@ Java_com_kulipai_luahook_library_NativeLib_get_1module_1base(JNIEnv *env, jobjec
     }
     env->ReleaseStringUTFChars(name, chars);
     return result;
+}
+
+extern "C" JNIEXPORT jbyteArray JNICALL
+Java_com_kulipai_luahook_library_NativeLib_read(JNIEnv *env, jobject thiz, jlong ptr, jint size) {
+    if (ptr == 0 || size <= 0) return nullptr;
+
+    jbyteArray byteArray = env->NewByteArray(size);
+    if (!byteArray) return nullptr;
+
+    env->SetByteArrayRegion(byteArray, 0, size, reinterpret_cast<jbyte *>(ptr));
+    return byteArray;
+}
+
+extern "C" JNIEXPORT jboolean JNICALL
+Java_com_kulipai_luahook_library_NativeLib_write(JNIEnv *env, jobject thiz, jlong ptr, jbyteArray data) {
+    if (ptr == 0 || data == nullptr) return JNI_FALSE;
+
+    jsize size = env->GetArrayLength(data);
+    if (size <= 0) return JNI_FALSE;
+
+    jbyte *buffer = env->GetByteArrayElements(data, nullptr);
+    if (!buffer) return JNI_FALSE;
+
+    std::memcpy((void *) ptr, buffer, size);
+    env->ReleaseByteArrayElements(data, buffer, 0);  // 0: copy back and free
+    return JNI_TRUE;
 }

--- a/app/src/main/cpp/luahook.cpp
+++ b/app/src/main/cpp/luahook.cpp
@@ -1,0 +1,17 @@
+#include <jni.h>
+#include "xdl.h"
+
+extern "C"
+JNIEXPORT jlong JNICALL
+Java_com_kulipai_luahook_library_NativeLib_get_1module_1base(JNIEnv *env, jobject thiz, jstring name) {
+    const char *chars = env->GetStringUTFChars(name, nullptr);
+    int64_t result = 0;
+    void *handle = xdl_open(chars, XDL_DEFAULT);
+    if (handle != nullptr) {
+        xdl_info_t info;
+        xdl_info(handle, XDL_DI_DLINFO, &info);
+        result = (int64_t) info.dli_fbase;
+    }
+    env->ReleaseStringUTFChars(name, chars);
+    return result;
+}

--- a/app/src/main/java/com/kulipai/luahook/library/HookLib.kt
+++ b/app/src/main/java/com/kulipai/luahook/library/HookLib.kt
@@ -1450,6 +1450,8 @@ class HookLib(private val lpparam: LPParam, private val scriptName: String = "")
                 }
             }
         }
+
+        globals["native"] = NativeLib().toLuaTable()
     }
 
 

--- a/app/src/main/java/com/kulipai/luahook/library/NativeLib.kt
+++ b/app/src/main/java/com/kulipai/luahook/library/NativeLib.kt
@@ -11,9 +11,10 @@ class NativeLib {
         System.loadLibrary("luahook")
     }
 
-    // 获取指定名称的so在进程中的基址,
-    // 如果还没有被加载到进程中, 则返回 0
     external fun get_module_base(name: String): Long
+
+    external fun read(ptr: Long, size: Int): ByteArray?
+    external fun write(ptr: Long, data: ByteArray): Boolean
 
     fun toLuaTable(): LuaTable {
         val table = LuaTable()
@@ -22,6 +23,27 @@ class NativeLib {
                 val name = args.arg(1).tojstring()
                 val base = get_module_base(name)
                 return CoerceJavaToLua.coerce(base)
+            }
+        }
+        table["read"] = object : VarArgFunction() {
+            override fun invoke(args: Varargs): LuaValue {
+                val ptr = args.arg(1).tolong()
+                val size = args.arg(2).toint()
+                val data = read(ptr, size) ?: return NIL
+                val table = LuaTable(data.size, 0)
+                for (i in 0 until data.size)
+                    table[i + 1] = CoerceJavaToLua.coerce(data[i])
+                return table
+            }
+        }
+        table["write"] = object : VarArgFunction() {
+            override fun invoke(args: Varargs): LuaValue {
+                val ptr = args.arg(1).tolong()
+                val data = args.arg(2).checktable()
+                val bytes = ByteArray(data.length()) { idx ->
+                    data.get(idx + 1).checkint().toByte()
+                }
+                return CoerceJavaToLua.coerce(write(ptr, bytes))
             }
         }
         return table

--- a/app/src/main/java/com/kulipai/luahook/library/NativeLib.kt
+++ b/app/src/main/java/com/kulipai/luahook/library/NativeLib.kt
@@ -1,0 +1,29 @@
+package com.kulipai.luahook.library
+
+import org.luaj.LuaTable
+import org.luaj.LuaValue
+import org.luaj.Varargs
+import org.luaj.lib.VarArgFunction
+import org.luaj.lib.jse.CoerceJavaToLua
+
+class NativeLib {
+    init {
+        System.loadLibrary("luahook")
+    }
+
+    // 获取指定名称的so在进程中的基址,
+    // 如果还没有被加载到进程中, 则返回 0
+    external fun get_module_base(name: String): Long
+
+    fun toLuaTable(): LuaTable {
+        val table = LuaTable()
+        table["get_module_base"] = object : VarArgFunction() {
+            override fun invoke(args: Varargs): LuaValue {
+                val name = args.arg(1).tojstring()
+                val base = get_module_base(name)
+                return CoerceJavaToLua.coerce(base)
+            }
+        }
+        return table
+    }
+}


### PR DESCRIPTION
New function `native.read`, `native.write`: direct memory access (warning: this may cause a segfault)