### PR TITLE
Add `native.resolve_symbol` function to resolve exported symbols of a library

### DIFF
--- a/app/src/main/java/com/kulipai/luahook/NewHook.kt
+++ b/app/src/main/java/com/kulipai/luahook/NewHook.kt
@@ -22,6 +22,7 @@ import org.luaj.lib.jse.CoerceJavaToLua
 import org.luaj.lib.jse.JsePlatform
 import top.sacz.xphelper.XpHelper
 import java.io.File
+import kotlin.concurrent.thread
 
 lateinit var  LPParam_processName: String
 
@@ -139,7 +140,9 @@ class NewHook(base: XposedInterface, param: ModuleLoadedParam) : XposedModule(ba
         suparam = createStartupParam(this.applicationInfo.sourceDir)
         XpHelper.initZygote(suparam)
 
-        LuaHook_init(ModuleInterfaceParamWrapper(lpparam))
+        thread {
+            LuaHook_init(ModuleInterfaceParamWrapper(lpparam))
+        }
 
     }
 

--- a/app/src/main/java/com/kulipai/luahook/library/NativeLib.kt
+++ b/app/src/main/java/com/kulipai/luahook/library/NativeLib.kt
@@ -60,6 +60,14 @@ class NativeLib {
             }
         }
 
+        table["sleep"] = object : VarArgFunction() {
+            override fun invoke(args: Varargs): Varargs? {
+                val millis = args.arg(1).tolong()
+                Thread.sleep(millis)
+                return NIL
+            }
+        }
+
         table["get_module_base"] = table["module_base"] // 被重命名的函数
 
         return table


### PR DESCRIPTION
Rename `native.get_module_base` to `native.module_base`
Rename the Kotlin-level function `module_base` to `moduleBase`
